### PR TITLE
wireup signin, clear errormessage

### DIFF
--- a/rn-tracks/src/Components/AuthForm.js
+++ b/rn-tracks/src/Components/AuthForm.js
@@ -18,7 +18,7 @@ const AuthForm = ({header, errorMessage, submitButtonTitle, submit}) => {
             <Input label={"Password"} value={password} onChangeText={setPassword} autoCapitalize='none' autoCorrect={false} secureTextEntry />
             {errorMessage ? <Text  style={styles.errMessage}>{errorMessage}</Text> : null }
             <Spacer>
-                <Button title={"Signup"} onPress={() => submit({email, password})}/>
+                <Button title={submitButtonTitle} onPress={() => submit({email, password})}/>
             </Spacer>
         </>
     )

--- a/rn-tracks/src/Context/authContext.js
+++ b/rn-tracks/src/Context/authContext.js
@@ -7,8 +7,10 @@ const authReducer = (state, action) => {
     switch(action.type){
         case 'errMessage':
             return {...state, errMessage: action.payload};
-        case 'signup':
+        case 'signin':
             return { token: action.payload, errMessage: ''};
+        case 'clear_errorMessage':
+            return { ...state, errMessage: '' }
         default:
             return state;
     }
@@ -18,18 +20,25 @@ const signup = (dispatch) => async ({email, password}) => {
     try {
         const response = await trackerApi.post('/signup', {email, password} );
         await AsyncStorage.setItem('token', response.data.token);
-        dispatch({ type: 'signup', payload: response.data.token });
+        dispatch({ type: 'signin', payload: response.data.token });
         navigate('TrackList');
-        console.log(response.data);
+        console.log(response);
     } catch (e) {
         console.log(e.response.data);
         dispatch({type: 'errMessage', payload: 'Invalid Data'})
     }
 }
 
-const signin = (dispatch) => {
-    return ({email, password}) => {
-        
+const signin = (dispatch) => async({email, password}) => {
+    try {
+        const response = await trackerApi.post('signin', { email, password });
+        await AsyncStorage.setItem('token', response.data.token);
+        dispatch({ type: 'signin', payload: response.data.token });
+        navigate('TrackList');
+        console.log(response);
+    } catch (e) {
+        console.log(e.response.data);
+        dispatch({type: 'errMessage', payload: 'Incorrect Credentials'})
     }
 }
 
@@ -38,8 +47,14 @@ const signout = (dispatch) => {
     }
 }
 
+const clearError = (dispatch) => {
+    return () => {
+        dispatch({ type: 'clear_errorMessage' })
+    }
+}
+
 export const { Provider, Context } = createDataContext(
     authReducer,
-    {signin, signout, signup},
+    {signin, signout, signup, clearError},
     { token: null, errMessage: '' }
 )

--- a/rn-tracks/src/screens/SigninScreen.js
+++ b/rn-tracks/src/screens/SigninScreen.js
@@ -1,17 +1,22 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import NavLink from '../Components/NavLink';
 import AuthForm from '../Components/AuthForm';
 import Spacer from '../Components/Spacer';
+import { Context } from '../Context/authContext';
+import { NavigationEvents } from 'react-navigation';
 
-const SigninScreen = () => {
+const SigninScreen = ({navigation}) => {
+  const { state, signin, clearError } = useContext(Context);
+
   return (
     <View style={styles.container}>
+      <NavigationEvents onWillBlur={clearError}/>
       <AuthForm
           header='Signin Tracker'
-          errorMessage=''
+          errorMessage={state.errMessage}
           submitButtonTitle='Signin'
-          submit={() => {}}
+          submit={signin}
       />
 
       <NavLink

--- a/rn-tracks/src/screens/SignupScreen.js
+++ b/rn-tracks/src/screens/SignupScreen.js
@@ -1,19 +1,21 @@
-import React, {useState, useContext} from 'react';
+import React, {useState, useContext, useEffect} from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { Text, Input, Button } from 'react-native-elements';
 import Spacer from '../Components/Spacer';
 import {Context as AuthContext} from '../Context/authContext';
 import AuthForm from '../Components/AuthForm';
 import NavLink from '../Components/NavLink';
+import { NavigationEvents } from 'react-navigation';
 
 
 const SignupScreen = ({navigation}) => {
-    const {state, signup} = useContext(AuthContext);
+    const {state, signup, clearError} = useContext(AuthContext);
 
     console.log(state);
 
   return (
       <View style={styles.container}>
+        <NavigationEvents onWillBlur={clearError}/>
           <AuthForm
             style={styles.authProp}
             header={"Signup Tracker"}


### PR DESCRIPTION
- wireup signin screen to AuthContext to have functionality

- in reducer function, renamed `signup` case to `signin` since adding another `signin` case would achieve identical results.

- Upon invoking error in signin/signup screen i.e. _invalid credentials_, error message should removed upon transitioning from current screen to other screen i.e. _error message on signin should clear up when going back to signup screen_